### PR TITLE
Add an extra newline if there isn't one

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -3,5 +3,5 @@ require 'bundler/gem_tasks'
 task :default => :test
 
 task :test do
-  system "bundle exec rspec spec"
+  system "bundle exec rspec spec --color --format documentation"
 end

--- a/lib/pimpmychangelog/pimper.rb
+++ b/lib/pimpmychangelog/pimper.rb
@@ -18,7 +18,11 @@ module PimpMyChangelog
     def better_changelog
       parsed_changelog = Parser.new(changelog)
 
-      linkify_changelog(parsed_changelog.content) +
+      # If the file doesn't have an extra newline at the end the separator gets rendered
+      # as part of the changelog. So add an extra newline in that case.
+      extra_newline_if_required = parsed_changelog.content.match(/\n\n\Z/) ? "" : "\n"
+
+      linkify_changelog(parsed_changelog.content) + extra_newline_if_required +
         links_definitions(parsed_changelog.issues, parsed_changelog.contributors)
     end
 

--- a/spec/pimper_spec.rb
+++ b/spec/pimper_spec.rb
@@ -18,8 +18,16 @@ describe Pimper do
 
     subject { better_changelog }
 
-    context "when the changelog does not contain any reference to issues or users" do
-      let(:changelog) { 'ChangeLog' }
+    context "when the changelog does not contain any reference to issues or users and no extra newline" do
+      let(:changelog) { "ChangeLog\n" }
+
+      it "should return the original changelog with an extra newline" do
+        better_changelog.should == changelog + "\n"
+      end
+    end
+
+    context "when the changelog already includes an extra newline" do
+      let(:changelog) { "ChangeLog\n\n" }
 
       it "should return the original changelog" do
         better_changelog.should == changelog


### PR DESCRIPTION
- If there is no extra newline at the end of file, the separator gets
  rendered as part of the changelog.
- Add `--color` and `--format documentation` options to `rake rspec` as it
  makes the tests more readable when running locally as well as on
  travis-ci.
