### PR TITLE
Handle repos that don't end in .git

### DIFF
--- a/lib/pimpmychangelog/git_remote.rb
+++ b/lib/pimpmychangelog/git_remote.rb
@@ -4,7 +4,7 @@ class GitRemote
     # Define recurring patterns
     (?<part> [\w\d-]+ ){0}
 
-    (?<user>\g<part>)/(?<repo>\g<part>).git$
+    (?<user>\g<part>)/(?<repo>\g<part>)(.git)?$
   }x
 
   def initialize(url = nil)


### PR DESCRIPTION
Github repos can be cloned without the `.git` at the end, which made the regex not match (and explode with `undefined method '[]' for nil:NilClass`).