### PR TITLE
Retrieve git-remote from local configuration

### DIFF
--- a/lib/pimpmychangelog/git_remote.rb
+++ b/lib/pimpmychangelog/git_remote.rb
@@ -29,6 +29,6 @@ class GitRemote
   end
 
   def run_command
-   `git remote show origin | grep "Fetch URL"`
+    `git config --get remote.origin.url`
   end
 end

--- a/pimpmychangelog.gemspec
+++ b/pimpmychangelog.gemspec
@@ -20,6 +20,7 @@ Gem::Specification.new do |s|
   s.require_paths = ["lib"]
 
   s.add_development_dependency "rspec"
+  s.add_development_dependency "rspec-its"
   s.add_development_dependency "guard-rspec"
   s.add_development_dependency "rake"
 end

--- a/spec/git_remote_spec.rb
+++ b/spec/git_remote_spec.rb
@@ -14,4 +14,13 @@ describe GitRemote do
     its(:user) { should == 'pcreux' }
     its(:project) { should == 'pimpmychangelog' }
   end
+
+  context "when no URL is passed" do
+    subject { described_class.new }
+
+    # We can't match an exact user, as this depends on who
+    # has checked out this repository.
+    its(:user) { should be_a(String) }
+    its(:project) { should == 'pimpmychangelog' }
+  end
 end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,3 +1,5 @@
+require 'rspec/its'
+
 require File.expand_path('../../lib/pimpmychangelog', __FILE__)
 
 include PimpMyChangelog


### PR DESCRIPTION
When running `pimpmychangelog` from CI, I encountered this issue:

When running
```ruby
PimpMyChangelog::CLI.run!
```
in CircleCI I get this prompt:
```
The authenticity of host 'github.com (140.82.112.4)' can't be established.
RSA key fingerprint is SHA256:nThbg6kXUpJWGl7E1IGOCspRomTxdCARLviKw6E5SY8.
Are you sure you want to continue connecting (yes/no)?
```

This happens because `pimpmychangelog` is trying to connect to the remote git repository when running:
```ruby
  def run_command
   `git remote show origin | grep "Fetch URL"`
  end
```
Our CI jobs don't have permission by default to connect back to the original git repository. We can work around this by trusting the SSH key above, or by using HTTPS, but I wondered if we even needed to connect back to the remote server at all. Turns out it's not necessary.

We are only interested in the GitHub "user" and git "repository name" for the git repository in the working directory. These are found in the origin url, which can be retrieved locally from config:
```sh
git config --get remote.origin.url
```

This PR uses the local configuration value, instead of fetching a remote value with the same information.

This PR also fixes the current CI failure, due to the removal of RSpec `its` syntax from the core library.